### PR TITLE
Fix missing Template and include Palette.hpp

### DIFF
--- a/Doxa/Algorithm.hpp
+++ b/Doxa/Algorithm.hpp
@@ -5,7 +5,7 @@
 
 #include "Image.hpp"
 #include "Parameters.hpp"
-
+#include "Palette.hpp"
 
 namespace Doxa
 {
@@ -89,12 +89,12 @@ namespace Doxa
 		/// </summary>
 		void ToBinary(Image& binaryImageOut, const Parameters& parameters)
 		{
-			const Pixel8 threshold = Threshold(Algorithm::grayScaleImageIn, parameters);
+			const Pixel8 threshold = Threshold(Algorithm<BinaryAlgorithm>::grayScaleImageIn, parameters);
 
-			for (int idx = 0; idx < Algorithm::grayScaleImageIn.size; ++idx)
+			for (int idx = 0; idx < Algorithm<BinaryAlgorithm>::grayScaleImageIn.size; ++idx)
 			{
 				binaryImageOut.data[idx] =
-					Algorithm::grayScaleImageIn.data[idx] <= threshold ?
+					Algorithm<BinaryAlgorithm>::grayScaleImageIn.data[idx] <= threshold ?
 					Palette::Black : Palette::White;
 			}
 		}


### PR DESCRIPTION
Thank you for your work on Doxa, I really appreciate it! I am quite excited by Doxa2.

Unfortunately I was not able to compile Doxa2 with clang (clang6) on Ubuntu. It seems to me that GlobalThreshold (in Algorithm.hpp) was missing some template parameter. Now I am just starting to learn c++ so I may have missed something really obvious.

I also included the Palette.hpp header in Algorithm.hpp but that maybe unnecessary as Palette.hpp maybe include earlier one (I needed it in order to debug the template parameter issue).

Thank you!