### PR TITLE
Allow newer versions of pybind11 (required for Python 3.11)

### DIFF
--- a/Bindings/Python/pyproject.toml
+++ b/Bindings/Python/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "pybind11==2.7.1"]
+requires = ["setuptools>=42", "wheel", "pybind11~=2.7"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This update is required for using the Python package doxapy with Debian stable which comes with Python 3.11.