### PR TITLE
2013 Pseudo Metrics

### DIFF
--- a/Doxa.Test/CMakeLists.txt
+++ b/Doxa.Test/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(
   ParametersTests.cpp
   PerformanceTests.cpp
   PNMTests.cpp
+  DIBCOUtilsTests.cpp
   RegionTests.cpp
 )
 

--- a/Doxa.Test/DIBCOUtilsTests.cpp
+++ b/Doxa.Test/DIBCOUtilsTests.cpp
@@ -1,0 +1,23 @@
+#include "pch.h"
+#include <sstream>
+#include <string>
+#include "DIBCOUtils.hpp"
+
+
+namespace Doxa::UnitTests
+{
+	TEST(DIBCOUtilsTests, ReadWeightsTest)
+	{
+		// Note: A sample copied from a DIBCO .dat file
+		std::string weights = "0.000000  1.000000  0.750000  0.500000";
+		std::stringstream stream(weights);
+
+		auto result = DIBCOUtils::ReadWeights(stream, 4);
+
+		EXPECT_EQ(result.size(), 4);
+		EXPECT_EQ(result.at(0), 0.0);
+		EXPECT_EQ(result.at(1), 1.0);
+		EXPECT_EQ(result.at(2), 0.75);
+		EXPECT_EQ(result.at(3), 0.5);
+	}
+}

--- a/Doxa.Test/Doxa.Test.vcxproj
+++ b/Doxa.Test/Doxa.Test.vcxproj
@@ -47,6 +47,7 @@
     <ClCompile Include="ParametersTests.cpp" />
     <ClCompile Include="PerformanceTests.cpp" />
     <ClCompile Include="PNMTests.cpp" />
+    <ClCompile Include="DIBCOUtilsTests.cpp" />
     <ClCompile Include="RegionTests.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>

--- a/Doxa.Test/Doxa.Test.vcxproj.filters
+++ b/Doxa.Test/Doxa.Test.vcxproj.filters
@@ -18,6 +18,7 @@
     <ClCompile Include="RegionTests.cpp" />
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="GridCalcTests.cpp" />
+    <ClCompile Include="DIBCOUtilsTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ImageFixture.hpp" />

--- a/Doxa.Test/PerformanceTests.cpp
+++ b/Doxa.Test/PerformanceTests.cpp
@@ -65,6 +65,35 @@ namespace Doxa::UnitTests
 		//EXPECT_EQ(ClassifiedPerformance::CalculateNRM(classifications), 0.00);
 	}
 
+	TEST(PerformanceTests, PseudoMetrics)
+	{
+		// NOTE: Based off of 2018 DIBCO Metrics PR sample
+		ClassifiedPerformance::Classifications classification;
+
+		/*
+		std::string projFolder = TestUtilities::ProjectFolder();
+		auto precisionWeights = DIBCOUtils::ReadWeightsFile(projFolder + "PR_PWeights.dat");
+		auto recallWeights = DIBCOUtils::ReadWeightsFile(projFolder + "PR_RWeights.dat");
+		auto controlImage = PNM::Read(projFolder + "PR_GT.pbm");
+		auto experimentImage = PNM::Read(projFolder + "PR_bin.pbm");
+
+		ClassifiedPerformance::CompareImages(classification, controlImage, experimentImage, precisionWeights, recallWeights);
+		*/
+
+		classification.truePositive = 61573;
+		classification.trueNegative = 251404;
+		classification.falsePositive = 1929;
+		classification.falseNegative = 6493;
+		classification.wpTruePositive = 0.0;
+		classification.wpFalsePositive = 644.86664099999996;
+		classification.wrTruePositive = 11562.182811000408;
+		classification.wrFalseNegative = 64.369443000000018;
+
+		EXPECT_NEAR(ClassifiedPerformance::CalculatePseudoPrecision(classification), 95.9875, 0.0001);
+		EXPECT_NEAR(ClassifiedPerformance::CalculatePseudoRecall(classification), 99.4464, 0.0001);
+		EXPECT_NEAR(ClassifiedPerformance::CalculatePseudoFMeasure(classification), 97.6863, 0.0001);
+	}
+
 	TEST(PerformanceTests, PSNRBoundsTest)
 	{
 		ClassifiedPerformance::Classifications classification;

--- a/Doxa.Test/pch.h
+++ b/Doxa.Test/pch.h
@@ -25,5 +25,6 @@
 #include <Bataineh.hpp>
 #include <ClassifiedPerformance.hpp>
 #include <DRDM.hpp>
+#include <DIBCOUtils.hpp>
 
 #include "gtest/gtest.h"

--- a/Doxa/DIBCOUtils.hpp
+++ b/Doxa/DIBCOUtils.hpp
@@ -1,0 +1,54 @@
+// Δoxa Binarization Framework
+// License: CC0 2025, "Freely you have received; freely give." - Matt 10:8
+#ifndef DIBCOUTILS_HPP
+#define DIBCOUTILS_HPP
+
+#include <fstream>
+#include <istream>
+#include <vector>
+
+
+namespace Doxa
+{
+	class DIBCOUtils
+	{
+	public:
+
+		/// <summary>
+		/// Read DIBCO Weighted .dat files.
+		/// </summary>
+		/// <remarks>"Performance Evaluation Methodology for Historical Document Image Binarization", 2013.</remarks>
+		static std::vector<double> ReadWeightsFile(const std::string& fileLocation, size_t allocatedSize = 0)
+		{
+			std::ifstream file;
+			file.open(fileLocation.c_str(), std::ios::binary);
+
+			const auto weights = DIBCOUtils::ReadWeights(file, allocatedSize);
+
+			file.clear();
+			file.close(); // Automatically closes, but done explicitly for posterity.
+
+			return weights;
+		}
+
+		/// <summary>
+		/// Read DIBCO Weighted content from either a file or string stream.
+		/// </summary>
+        static std::vector<double> ReadWeights(std::istream& stream, size_t allocatedSize = 0)
+        {
+			std::vector<double> values;
+			values.reserve(allocatedSize);
+
+            double value;
+            while (stream >> value)
+            {
+                values.push_back(value);
+            }
+
+            return values;
+        }
+	};
+}
+
+
+#endif //DIBCOUTILS_HPP

--- a/Doxa/Doxa.vcxitems
+++ b/Doxa/Doxa.vcxitems
@@ -39,6 +39,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)Palette.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Parameters.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)PNM.hpp" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)DIBCOUtils.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Region.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Sauvola.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Su.hpp" />

--- a/Doxa/LocalWindow.hpp
+++ b/Doxa/LocalWindow.hpp
@@ -3,7 +3,6 @@
 #ifndef LOCALWINDOW_HPP
 #define LOCALWINDOW_HPP
 
-#include <vector>
 #include <algorithm>
 #include "Image.hpp"
 #include "Palette.hpp"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ It is written in C++ but supports multiple language bindings.
 
 **Performance Metrics**
 * Overall Accuracy
-* F-Measure
+* F-Measure, Precision, Recall
+* Pseudo F-Meaure, Precision, Recall - "Performance Evaluation Methodology for Historical Document Image Binarization", 2013.
 * Peak Signal-To-Noise Ratio (PSNR)
 * Negative Rate Metric (NRM)
 * Matthews Correlation Coefficient (MCC)


### PR DESCRIPTION
Process DIBCO .dat files in order to calculate Pseudo F-Measure, Ps Recall, and Ps Precision.

K. Ntirogiannis, B. Gatos and I. Pratikakis,
"Performance Evaluation Methodology for Historical Document Image Binarization",
IEEE Trans. Image Proc., vol.22, no.2, pp. 595-609, Feb. 2013.

This will allow for a complete replacement of DIBCO_metrics.exe.
However, this will not generate the .dat files which will still necessitate the use of BinEvalWeights.exe.
I have reached out to Gatos and Pratikakis, asking if they would open source their BinEvalWeights.exe.

NOTE: These Pseudo Metrics are not to be confused with the 2010 version.